### PR TITLE
Fix: return 404 for non-existent articles (fixes #25)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 """Calm.com mock backend API."""
 from typing import Optional
-from fastapi import FastAPI, Query
+from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from app.data import ARTICLES, FEATURES, TESTIMONIALS, PRICING
 
@@ -35,7 +35,7 @@ def get_article(slug: str) -> dict:
     """Get a single article by slug."""
     article = next((a for a in ARTICLES if a["slug"] == slug), None)
     if article is None:
-        return {"error": "Article not found"}
+        raise HTTPException(status_code=404, detail="Article not found")
     return {"article": article}
 
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -49,11 +49,11 @@ def test_get_article_by_slug():
 
 
 def test_get_article_not_found():
-    """Should return error for non-existent slug."""
+    """Should return 404 for non-existent slug."""
     response = client.get("/api/articles/nonexistent")
-    assert response.status_code == 200
+    assert response.status_code == 404
     data = response.json()
-    assert "error" in data
+    assert "detail" in data
 
 
 def test_get_features():


### PR DESCRIPTION
## Summary
- Return HTTP 404 instead of 200 for non-existent article slugs
- Update test assertion

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)